### PR TITLE
Add explicit dict item for "unknown" flight status

### DIFF
--- a/flightphase.py
+++ b/flightphase.py
@@ -30,7 +30,7 @@ state_descent = fuzz.gaussmf(states, 3, 0.1)
 state_cruise = fuzz.gaussmf(states, 4, 0.1)
 state_level = fuzz.gaussmf(states, 5, 0.1)
 
-state_label_map = {1: 'GND', 2: 'CL', 3: 'DE', 4: 'CR', 5: 'LVL'}
+state_label_map = {1: 'GND', 2: 'CL', 3: 'DE', 4: 'CR', 5: 'LVL', 6: 'UNK'}
 
 
 # Visualize these universes and membership functions

--- a/flightphase.py
+++ b/flightphase.py
@@ -30,7 +30,7 @@ state_descent = fuzz.gaussmf(states, 3, 0.1)
 state_cruise = fuzz.gaussmf(states, 4, 0.1)
 state_level = fuzz.gaussmf(states, 5, 0.1)
 
-state_label_map = {1: 'GND', 2: 'CL', 3: 'DE', 4: 'CR', 5: 'LVL', 6: 'UNK'}
+state_label_map = {1: 'GND', 2: 'CL', 3: 'DE', 4: 'CR', 5: 'LVL', 6: 'NA'}
 
 
 # Visualize these universes and membership functions


### PR DESCRIPTION
If the flight phase classifier fails to choose a phase then this logic:
```
        if state > 6:
            state = 6
```
Sets the state value to 6, which is not in the `state_label_map` dict.
This PR adds value 6 to the dict as `NA`, signifying an unknown flight phase and preventing a crash should value 6 be encountered.